### PR TITLE
完善 stop_task 任务

### DIFF
--- a/src/core/task_project_manager.py
+++ b/src/core/task_project_manager.py
@@ -13,7 +13,7 @@ from typing import Dict, Union, Optional, List
 from requests.adapters import HTTPAdapter
 from abc import ABC, abstractmethod
 
-from utils.singleton import singleton
+from src.utils.singleton import singleton
 
 # 配置日志
 logging.basicConfig(
@@ -211,7 +211,7 @@ class TaskProjectManager:
         if project_key not in self.processes:
             raise TaskExecutionError(f"Tasker process {project_key} not found")
 
-        task_data = task.to_json() if isinstance(task, ProjectRunData) else {"task": task}
+        task_data = task.to_json() if isinstance(task, ProjectRunData) else task
 
         try:
             response = self._make_request(


### PR DESCRIPTION
修复发送 `STOP` 时解析错误。同时发现因为每个 TaskerThread 只有一个任务 queue 和一个线程，发送过去的 `STOP` 必须要等在这之前的所有任务都完成才能执行。现在为 TaskerThread 开启了一个额外的辅助线程来执行该类任务。