### PR TITLE
feat: add PlayCover MaaTools support

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -269,6 +269,18 @@ jobs:
             fi
           done
 
+          if [ "${{ matrix.os }}" != "win" ]; then
+            python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          path = Path("package/interface.json")
+          data = json.loads(path.read_text(encoding="utf-8"))
+          data["agent"]["child_exec"] = "./agent/agent"
+          path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+          PY
+          fi
+
       - name: Upload package artifact
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ MaaYYs 是一个面向《阴阳师》模拟器环境的自动化项目，项目�
 
 ### macOS / PlayCover
 
-1. 使用 Apple Silicon Mac，安装支持 MaaTools 的 fork 版 PlayCover；安装与设置可参考 [MAA 官方中文 macOS PlayCover 文档](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master/docs/zh-cn/manual/device/macos.md)。在其中安装 iOS 版阴阳师（Bundle ID：`com.netease.onmyoji`）并启用 MaaTools。
+1. 使用 Apple Silicon Mac，安装支持 MaaTools 的 fork 版 PlayCover。MaaYYs 的 macOS PlayCover/MaaTools 接入思路参考了 MAA（明日方舟）macOS 版方案；安装与设置可参考 [MAA 官方中文 macOS 使用手册](https://docs.maa.plus/zh-cn/manual/device/macos.html)。在其中安装 iOS 版阴阳师（Bundle ID：`com.netease.onmyoji`）并启用 MaaTools。
 2. 启动游戏，在 MXU 中添加设备并选择 `PlayCover`，填写 MaaTools 的实际监听地址；`127.0.0.1:1718` 仅为示例，不应写死，`1717` 也可能已被 MAA 占用。
-3. 保持横屏运行。目标识别坐标为 1280×720（`display_short_side: 720`），然后选择资源并配置任务。
+3. 保持横屏即可。`controller` 的 `display_short_side: 720` 是截图与识别的内部缩放基准，不要求 PlayCover 游戏窗口实际设置为 1280×720；可参考 MAA 手册按需调整分辨率，若识别异常可尝试 1080P。然后选择资源并配置任务。
 
 更详细的图文教程见 [doc/使用指南.md](doc/使用指南.md)。
 

--- a/README.md
+++ b/README.md
@@ -47,10 +47,17 @@ MaaYYs 是一个面向《阴阳师》模拟器环境的自动化项目，项目�
 
 1. 下载并解压 `MaaYYs-平台-架构-版本-MXU` 全量包。
 2. Windows 双击运行 `mxu.exe`；macOS / Linux 运行解压目录中的 `mxu`。
-3. 打开安卓模拟器，并确保模拟器已开启 ADB 调试。
-4. 在 MXU 中添加设备，选择自动搜索到的模拟器，或手动填写 ADB 路径和地址。
-5. 选择对应资源：官服、B 站服、华为服、应用宝服、OPPO 服、VIVO 服等。
-6. 勾选并配置要运行的任务，通常请从庭院界面启动；`打开游戏`、`关闭游戏` 等任务除外。
+
+### Android / ADB
+
+1. 打开安卓模拟器并启用 ADB 调试，在 MXU 中添加设备，选择自动搜索到的模拟器，或手动填写 ADB 路径和地址。
+2. 选择对应资源和任务，通常请从庭院界面启动；`打开游戏`、`关闭游戏` 等任务除外。
+
+### macOS / PlayCover
+
+1. 使用 Apple Silicon Mac，安装支持 MaaTools 的 fork 版 PlayCover；安装与设置可参考 [MAA 官方中文 macOS PlayCover 文档](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master/docs/zh-cn/manual/device/macos.md)。在其中安装 iOS 版阴阳师（Bundle ID：`com.netease.onmyoji`）并启用 MaaTools。
+2. 启动游戏，在 MXU 中添加设备并选择 `PlayCover`，填写 MaaTools 的实际监听地址；`127.0.0.1:1718` 仅为示例，不应写死，`1717` 也可能已被 MAA 占用。
+3. 保持横屏运行。目标识别坐标为 1280×720（`display_short_side: 720`），然后选择资源并配置任务。
 
 更详细的图文教程见 [doc/使用指南.md](doc/使用指南.md)。
 
@@ -180,6 +187,8 @@ chmod +x agent
 ```
 
 所以 Windows 本地调试时，编译出的 `agent.exe` 需要放在 `agent/agent.exe`。如果要在 macOS / Linux 本地调试，需要按对应平台调整 `child_exec`，或使用 CI 打出的对应平台包。
+
+源文件保留 Windows 默认路径；CI 生成 macOS / Linux 包时只修改包内 `interface.json` 副本，将 `child_exec` 调整为 `./agent/agent`。
 
 ### 启动完整 UI 调试
 

--- a/doc/使用指南.md
+++ b/doc/使用指南.md
@@ -39,9 +39,9 @@
 
 ### 4. 添加设备（macOS PlayCover）
 
-macOS 请使用 Apple Silicon，并准备支持 MaaTools 的 fork 版 PlayCover；安装与设置可参考 [MAA 官方中文 macOS PlayCover 文档](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master/docs/zh-cn/manual/device/macos.md)。在其中安装 iOS 版阴阳师（Bundle ID：`com.netease.onmyoji`），启用 MaaTools 并启动游戏；这不是普通 PlayCover 连接。
+macOS 请使用 Apple Silicon，并准备支持 MaaTools 的 fork 版 PlayCover。MaaYYs 的 macOS PlayCover/MaaTools 接入思路参考了 MAA（明日方舟）macOS 版方案；安装与设置可参考 [MAA 官方中文 macOS 使用手册](https://docs.maa.plus/zh-cn/manual/device/macos.html)。在其中安装 iOS 版阴阳师（Bundle ID：`com.netease.onmyoji`），启用 MaaTools 并启动游戏；这不是普通 PlayCover 连接。
 
-在 MXU 添加设备时选择 `PlayCover`，填写 MaaTools 的实际监听地址。`127.0.0.1:1718` 仅为示例，请以实际配置为准，不要写死；`1717` 可能已被 MAA 占用。目标识别坐标为 1280×720（`display_short_side: 720`），建议保持横屏运行。
+在 MXU 添加设备时选择 `PlayCover`，填写 MaaTools 的实际监听地址。`127.0.0.1:1718` 仅为示例，请以实际配置为准，不要写死；`1717` 可能已被 MAA 占用。保持横屏即可。`controller` 的 `display_short_side: 720` 是截图与识别的内部缩放基准，不要求 PlayCover 游戏窗口实际设置为 1280×720；可参考 MAA 手册按需调整分辨率，若识别异常可尝试 1080P。
 
 ### 5. 设置任务
 

--- a/doc/使用指南.md
+++ b/doc/使用指南.md
@@ -37,7 +37,13 @@
 
 > **提示**：如果这里没找到你的模拟器，别慌，可以手动添加。手动添加的教程在文章最后，也可以点 **[这里](#-手动添加设备)** 跳转。
 
-### 4. 设置任务
+### 4. 添加设备（macOS PlayCover）
+
+macOS 请使用 Apple Silicon，并准备支持 MaaTools 的 fork 版 PlayCover；安装与设置可参考 [MAA 官方中文 macOS PlayCover 文档](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master/docs/zh-cn/manual/device/macos.md)。在其中安装 iOS 版阴阳师（Bundle ID：`com.netease.onmyoji`），启用 MaaTools 并启动游戏；这不是普通 PlayCover 连接。
+
+在 MXU 添加设备时选择 `PlayCover`，填写 MaaTools 的实际监听地址。`127.0.0.1:1718` 仅为示例，请以实际配置为准，不要写死；`1717` 可能已被 MAA 占用。目标识别坐标为 1280×720（`display_short_side: 720`），建议保持横屏运行。
+
+### 5. 设置任务
 
 添加成功后，你应该就能在主页看到设备卡片了。首次启动前，需要进行一些设置。
 
@@ -51,7 +57,7 @@
 
 3.  接着就可以开始设置你要启动的任务了，依次设置就行。
 
-### 5. 启动任务！
+### 6. 启动任务！
 
 当所有需要设置的任务都设置好之后，就可以点击右上角的 **“连接”** 或 **“启动”** 来启动任务了。
 

--- a/interface.json
+++ b/interface.json
@@ -16,6 +16,16 @@
       "label": "安卓设备",
       "type": "Adb",
       "description": "通过ADB连接的安卓设备"
+    },
+    {
+      "name": "PlayCover",
+      "label": "PlayCover（macOS）",
+      "type": "PlayCover",
+      "description": "通过支持 MaaTools 的 PlayCover 控制 iOS 版阴阳师",
+      "display_short_side": 720,
+      "playcover": {
+        "uuid": "com.netease.onmyoji"
+      }
     }
   ],
   "resource": [


### PR DESCRIPTION
## 中文说明

### 改动内容

- 为 Apple Silicon Mac 上的 iOS 版《阴阳师》新增 `PlayCover` 控制器。
- 补充 MaaTools 版 PlayCover 的安装、连接地址和横屏运行说明。
- macOS / Linux 发布包仅修改打包副本中的 agent 路径，保留 Windows 原路径。

### 方案来源与使用说明

本方案参考了 MAA（明日方舟）macOS 版的 PlayCover / MaaTools 接入思路。安装与 PlayCover 设置可参考 [MAA 官方中文 macOS 使用手册](https://docs.maa.plus/zh-cn/manual/device/macos.html)。

- 阴阳师 Bundle ID：`com.netease.onmyoji`
- `127.0.0.1:1718` 只是连接地址示例，应填写 MaaTools 实际监听地址；`1717` 可能已被 MAA 占用。
- PlayCover 游戏窗口不强制设置为 1280×720。`display_short_side: 720` 是 MaaFramework 截图与识别的内部缩放基准；保持横屏即可，可按需要调整分辨率，识别异常时可参考 MAA 手册尝试 1080P。

### 验证

- 已在 Apple Silicon Mac 上通过 MXU 连接 PlayCover MaaTools。
- 已验证 `com.netease.onmyoji` 的截图和触控输入。
- 已通过 PlayCover 连接完成多项日常收菜任务。
- `interface.json`、发布工作流和平台 agent 路径检查通过。
- `git diff --check` 通过。

本次未修改 Go 源码。本机 Go 版本为 1.17，而仓库工作流使用 Go 1.24，因此 Go 测试交由 CI 执行。

---

## English

### Changes

- add a `PlayCover` controller for the iOS version of Onmyoji on Apple Silicon Macs
- document the MaaTools-enabled PlayCover setup, connection address, and landscape usage
- rewrite only the packaged `interface.json` agent path for macOS and Linux while preserving the existing Windows path

### Background and setup

This integration follows the PlayCover / MaaTools approach used by MAA for Arknights on macOS. See the [MAA macOS guide](https://docs.maa.plus/zh-cn/manual/device/macos.html) for the PlayCover setup.

- Onmyoji bundle ID: `com.netease.onmyoji`
- `127.0.0.1:1718` is only an example; use the actual MaaTools listening address. Port `1717` may already be occupied by MAA.
- The PlayCover game window does not have to be set to 1280×720. `display_short_side: 720` is the internal screenshot and recognition scaling baseline used by MaaFramework. Keep the game in landscape and adjust the PlayCover resolution as needed.

### Validation

- connected MXU to PlayCover MaaTools on an Apple Silicon Mac
- verified screenshot and touch input for `com.netease.onmyoji`
- completed multiple daily collection tasks through the PlayCover connection
- parsed `interface.json` and the release workflow and verified platform-specific agent paths
- ran `git diff --check`

This PR does not modify Go source. The local Go toolchain is 1.17 while the workflow uses Go 1.24, so the existing Go tests are left to CI.
