### PR TITLE
fix: 为999奖励点击设置默认ROI

### DIFF
--- a/resource_pack/base/pipeline/活动/限定/999.json
+++ b/resource_pack/base/pipeline/活动/限定/999.json
@@ -366,6 +366,14 @@
   "999_奖励_点击一下": {
     "action": "Custom",
     "custom_action": "HumanTouch",
+    "custom_action_param": {
+      "ROI_1": [
+        141,
+        524,
+        997,
+        196
+      ]
+    },
     "expected": "点击屏幕继续",
     "next": [
       "999-手动战斗-识别是否返回爬塔界面",


### PR DESCRIPTION

## 问题说明

999 流程在奖励结算页面出现奖励属性详情弹窗时，可能无法识别“点击屏幕继续”，最终导致任务失败。

故障日志中可以看到：

```text
custom_action_param=null
```

随后 HumanTouch 使用默认点击范围进行随机点击，可能点击到奖励内容或属性详情弹窗区域，导致“点击屏幕继续”无法被识别。节点超时后，999 任务失败。

## 修复内容

为 `999_奖励_点击一下` 节点补充默认的 `custom_action_param`：

- 增加默认 `ROI_1`；
- 关闭“自定义点击策略”开关时，仍使用固定的点击 ROI；
- 打开“自定义点击策略”开关时，继续使用任务配置中的动态参数；
- 开关关闭和开启时使用相同的 `ROI_1`；
- 保留 HumanTouch 的随机点击、单击/双击和等待逻辑。

## 验证情况

- 已验证关闭自定义点击策略开关时的 ROI；
- 已确认基础节点和动态覆盖配置中的 ROI 一致：`[141, 524, 997, 196]`；
- 已确认修改前日志中的 `custom_action_param` 为 `null`；
- 已确认修改前节点因无法识别“点击屏幕继续”而超时并导致任务失败；
- 已检查修改后的 JSON 格式。

## 附件

以下附件为修复前出现问题时的截图和完整日志：

- 故障截图：奖励界面出现属性详情弹窗；
- 故障截图：999 任务最终失败；
- 完整运行日志压缩包。
<img width="1729" height="973" alt="
codex-clipboard-89cd05f1-5e12-4687-854b-e3d1759a9a21" src="https://github.com/user-attachments/assets/7a01ed46-582e-4e11-a1f8-313611338b8f" />
<img width="2043" height="1365" alt="codex-clipboard-9a6062d7-4c5b-4f8f-8359-25a3daf3a844" src="https://github.com/user-attachments/assets/4943ab65-9581-47a3-b1ec-10c010b8a6dd" />
[MaaYYs-logs-v3.15.2-20260905-233119-part01.zip](https://github.com/user-attachments/files/31867936/MaaYYs-logs-v3.15.2-20260905-233119-part01.zip)

