### PR TITLE
fix(pipeline): 修复自动999返回爬塔界面识别遗漏繁体字"銳"的问题

### DIFF
--- a/resource_pack/base/pipeline/活动/限定/999.json
+++ b/resource_pack/base/pipeline/活动/限定/999.json
@@ -99,7 +99,7 @@
     "recognition": "DirectHit"
   },
   "999-手动战斗-识别是否返回爬塔界面": {
-    "expected": "虚无精锐",
+    "expected": "虚无精锐|虚无精銳",
     "recognition": "OCR",
     "roi": [
       65,


### PR DESCRIPTION
修复自动999活动任务在战斗返回爬塔界面时的 OCR 文本兼容问题。

Fixes #121

### 修复内容
- 修改 `resource_pack/base/pipeline/活动/限定/999.json` 中的 `999-手动战斗-识别是否返回爬塔界面` 节点，将 `expected` 从 `"虚无精锐"` 补充为 `"虚无精锐|虚无精銳"`。

### 解决的问题
- 解决战斗结算返回爬塔主界面后，因 OCR 识别为繁体“銳”被过滤导致判定未返回、任务陷入 200s 超时卡死无法循环下一轮的 Bug。
